### PR TITLE
Fix: show newly created board on homepage without reload

### DIFF
--- a/src/app/(dashboard)/_components/boards/board-list.tsx
+++ b/src/app/(dashboard)/_components/boards/board-list.tsx
@@ -10,14 +10,12 @@ interface BoardListProps {
 }
 
 const BoardList: FC<BoardListProps> = async ({
-  boards,
+  boards = [],
   showCreateBoardBtn = false,
 }) => {
   return (
     <div className="grid grid-cols-2 gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-      {boards.map((board) => (
-        <BoardItem key={board.id} board={board} />
-      ))}
+      {boards?.map((board) => <BoardItem key={board.id} board={board} />)}
 
       {showCreateBoardBtn && (
         <Button

--- a/src/app/(dashboard)/_components/boards/board-list.tsx
+++ b/src/app/(dashboard)/_components/boards/board-list.tsx
@@ -15,7 +15,9 @@ const BoardList: FC<BoardListProps> = async ({
 }) => {
   return (
     <div className="grid grid-cols-2 gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-      {boards?.map((board) => <BoardItem key={board.id} board={board} />)}
+      {boards.map((board) => (
+        <BoardItem key={board.id} board={board} />
+      ))}
 
       {showCreateBoardBtn && (
         <Button

--- a/src/app/(dashboard)/_components/boards/boards.tsx
+++ b/src/app/(dashboard)/_components/boards/boards.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { FC, useContext } from "react";
-import { BoardListContext } from "@/context/boardList-context";
+import { FC } from "react";
+import { useBoardListContext } from "@/context/board-list-context";
 import { cn } from "@/lib/utils";
 import Navigate from "@/components/navigate";
 import BoardList from "@/app/(dashboard)/_components/boards/board-list";
@@ -11,7 +11,7 @@ interface BoardsProps {
 }
 
 const Boards: FC<BoardsProps> = ({ className }) => {
-  const { boardList, guestBoards, session } = useContext(BoardListContext);
+  const { boardList, guestBoards, session } = useBoardListContext();
   if (!session) return <Navigate to="/login" />;
 
   return (

--- a/src/app/(dashboard)/_components/boards/boards.tsx
+++ b/src/app/(dashboard)/_components/boards/boards.tsx
@@ -1,26 +1,23 @@
-import { FC } from "react";
-import { getServerSession } from "next-auth";
+"use client";
+
+import { FC, useContext } from "react";
+import { BoardListContext } from "@/context/boardList-context";
 import { cn } from "@/lib/utils";
 import Navigate from "@/components/navigate";
 import BoardList from "@/app/(dashboard)/_components/boards/board-list";
-import { getUserBoards, getUserGuestBoards } from "@/app/(dashboard)/actions";
-import { options } from "@/app/api/auth/[...nextauth]/options";
 
 interface BoardsProps {
   className?: string;
 }
 
-const Boards: FC<BoardsProps> = async ({ className }) => {
-  const session = await getServerSession(options);
+const Boards: FC<BoardsProps> = ({ className }) => {
+  const { boardList, guestBoards, session } = useContext(BoardListContext);
   if (!session) return <Navigate to="/login" />;
-
-  const userBoards = await getUserBoards(session.user.id);
-  const guestBoards = await getUserGuestBoards(session.user.id);
 
   return (
     <div className={cn("flex w-full flex-col gap-4", className)}>
       <h2 className="text-2xl font-semibold uppercase">Your Boards</h2>
-      <BoardList boards={userBoards} showCreateBoardBtn />
+      <BoardList boards={boardList} showCreateBoardBtn />
 
       {guestBoards.length > 0 && (
         <>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,8 +1,13 @@
 import { redirect } from "next/navigation";
 import { AuthContextProvider } from "@/context/auth-context";
+import BoardListContextProvider from "@/context/boardList-context";
 import { getServerSession } from "next-auth";
 import Navbar from "@/components/navbar/navbar";
-import { getUserById } from "@/app/(dashboard)/actions";
+import {
+  getUserBoards,
+  getUserById,
+  getUserGuestBoards,
+} from "@/app/(dashboard)/actions";
 import { options } from "@/app/api/auth/[...nextauth]/options";
 
 export default async function DashboardLayout({
@@ -14,11 +19,19 @@ export default async function DashboardLayout({
   if (!session) redirect("/login");
 
   const user = await getUserById(session.user.id);
+  const userBoards = await getUserBoards(session.user.id);
+  const guestBoards = await getUserGuestBoards(session.user.id);
 
   return (
     <AuthContextProvider user={user}>
-      <Navbar />
-      {children}
+      <BoardListContextProvider
+        session={session}
+        guestBoards={guestBoards}
+        userBoards={userBoards}
+      >
+        <Navbar />
+        {children}
+      </BoardListContextProvider>
     </AuthContextProvider>
   );
 }

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { AuthContextProvider } from "@/context/auth-context";
-import BoardListContextProvider from "@/context/boardList-context";
+import BoardListContextProvider from "@/context/board-list-context";
 import { getServerSession } from "next-auth";
 import Navbar from "@/components/navbar/navbar";
 import {

--- a/src/app/(dashboard)/new/_components/new-form.tsx
+++ b/src/app/(dashboard)/new/_components/new-form.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import {
-  useContext,
   useEffect,
   experimental_useEffectEvent as useEffectEvent,
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/context/auth-context";
-import { BoardListContext } from "@/context/boardList-context";
+import { useBoardListContext } from "@/context/board-list-context";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Board } from "@prisma/client";
 import { useForm } from "react-hook-form";
@@ -36,7 +35,7 @@ import { createBoard } from "@/app/(dashboard)/new/actions";
 const NewForm = () => {
   const { user } = useAuthContext();
   const router = useRouter();
-  const { setBoardList } = useContext(BoardListContext);
+  const { setBoardList, boardList } = useBoardListContext();
   const [error, setError] = useState<string>();
 
   const form = useForm<z.infer<typeof boardSchema>>({
@@ -64,10 +63,7 @@ const NewForm = () => {
         ...createdBoard,
         owner: user,
       };
-      setBoardList((prevBoardList) => [
-        createdBoardWithOwner,
-        ...prevBoardList,
-      ]);
+      setBoardList([createdBoardWithOwner, ...boardList]);
       router.push(`/${user.username}/${createdBoard.slug}`);
     } catch (e: any) {
       setError(e.message);

--- a/src/context/board-list-context.tsx
+++ b/src/context/board-list-context.tsx
@@ -13,9 +13,9 @@ import { BoardWithOwner } from "@/components/navbar/dropdowns/boards-dropdown";
 interface BoardListContextProps {
   boardList: BoardWithOwner[];
   guestBoards: BoardWithOwner[];
-  setBoardList: React.Dispatch<React.SetStateAction<BoardWithOwner[]>>;
+  setBoardList: (boards: BoardWithOwner[]) => void;
   session: Session | null;
-  setGuestBoard: React.Dispatch<React.SetStateAction<BoardWithOwner[]>>;
+  setGuestBoard: (boards: BoardWithOwner[]) => void;
 }
 
 export const BoardListContext = createContext<BoardListContextProps>({
@@ -26,7 +26,7 @@ export const BoardListContext = createContext<BoardListContextProps>({
   setGuestBoard: () => {},
 });
 
-export function useBoardContext() {
+export function useBoardListContext() {
   return useContext(BoardListContext) as BoardListContextProps;
 }
 

--- a/src/context/boardList-context.tsx
+++ b/src/context/boardList-context.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useContext,
+  useState,
+} from "react";
+import { type Session } from "next-auth";
+import { BoardWithOwner } from "@/components/navbar/dropdowns/boards-dropdown";
+
+interface BoardListContextProps {
+  boardList: BoardWithOwner[];
+  guestBoards: BoardWithOwner[];
+  setBoardList: React.Dispatch<React.SetStateAction<BoardWithOwner[]>>;
+  session: Session | null;
+  setGuestBoard: React.Dispatch<React.SetStateAction<BoardWithOwner[]>>;
+}
+
+export const BoardListContext = createContext<BoardListContextProps>({
+  boardList: [],
+  guestBoards: [],
+  setBoardList: () => {},
+  session: null,
+  setGuestBoard: () => {},
+});
+
+export function useBoardContext() {
+  return useContext(BoardListContext) as BoardListContextProps;
+}
+
+interface BoardListContextProviderProps extends PropsWithChildren {
+  userBoards: BoardWithOwner[];
+  guestBoards: BoardWithOwner[];
+  session: Session | null;
+}
+const BoardListContextProvider: FC<BoardListContextProviderProps> = ({
+  children,
+  session,
+  userBoards,
+  guestBoards,
+}) => {
+  const [boardList, setBoardList] = useState<BoardWithOwner[]>(userBoards);
+  const [userGuestBoards, setGuestBoard] =
+    useState<BoardWithOwner[]>(guestBoards);
+
+  return (
+    <BoardListContext.Provider
+      value={{
+        boardList,
+        setBoardList,
+        guestBoards: userGuestBoards,
+        session,
+        setGuestBoard,
+      }}
+    >
+      {children}
+    </BoardListContext.Provider>
+  );
+};
+
+export default BoardListContextProvider;


### PR DESCRIPTION
## Description

Fixes #42 : Issue was that newly created board was not getting updated without reload. To resolve this I created a context for the list of created boards and updated the state accordingly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style and structure of this project
- [x] My code follows the principles of clean code
- [x] My changes generate no new warnings, bugs or errors


## Tags

`hactoberfest`, `bug-fix`, `hactoberfest2023`