### PR TITLE
Fix: card reopen issue

### DIFF
--- a/src/app/(dashboard)/[username]/[boardSlug]/@card/(.)cards/[cardId]/_components/header/card-header.tsx
+++ b/src/app/(dashboard)/[username]/[boardSlug]/@card/(.)cards/[cardId]/_components/header/card-header.tsx
@@ -36,7 +36,6 @@ const CardHeader = () => {
         variant="ghost"
         onClick={() => {
           router.back();
-          router.refresh();
         }}
       >
         <X />


### PR DESCRIPTION
## Description

#30 on the board page  on clicking card , the page of the card appears (it's a popup). On closing popup, when want to reopen popup it was not getting closed, had to refresh. To resolve, made some changes  when popup closes .

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style and structure of this project
- [x] My code follows the principles of clean code
- [x] My changes generate no new warnings, bugs or errors

## Tags
`hactoberfest`, `bug-fixes`
